### PR TITLE
Untitled

### DIFF
--- a/system-uuid.cabal
+++ b/system-uuid.cabal
@@ -1,5 +1,5 @@
 name                          : system-uuid
-version                       : 1.3.0
+version                       : 1.3.1
 category                      : System
 license                       : BSD3
 license-file                  : LICENSE
@@ -22,10 +22,15 @@ extra-source-files            : README
                                 MacroMacros.hs
                                 Messages.hs
 
+flag split-base
 
 library
-  build-depends               : base <= 4
-                              , containers
+  if flag(split-base)
+    build-depends : base >= 4 && < 5
+  else
+    build-depends : base < 4
+
+  build-depends               : containers
                               , binary
                               , template-haskell
                               , parsec


### PR DESCRIPTION
Hi Jason,

I fixed system-uuid to build with ghc 7, because my package failed building on hackage at all due to this incompatibility. (see http://hackage.haskell.org/packages/archive/greg-client/1.0.0/logs/failure/ghc-7.0)
